### PR TITLE
update fis to fix node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fis-plus",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Front End Integrated Solution for PC",
   "main": "fis-plus.js",
   "bin": {
@@ -16,7 +16,7 @@
     "url": "https://github.com/fex-team/fis-plus.git"
   },
   "dependencies": {
-    "fis": "1.9.44",
+    "fis": "1.10.1",
     "fis-preprocessor-extlang": "0.0.8",
     "fis-prepackager-widget-inline": "0.0.9",
     "fis-postprocessor-require-async": "0.0.9",


### PR DESCRIPTION
fis-sprite-csssprites因为依赖images的关系，不兼容Node 4+

fis@1.10.1 版本里面更新了最新的依赖

但fis-plus 这个版本依赖的是 fis@1.9.44，所以依赖于 fis-plus的项目都不能自动合并雪碧图

希望fis-plus能升级下 fis版本并发布到npm